### PR TITLE
fix: route Apply buttons based on program funding type

### DIFF
--- a/src/components/ProgramCard.tsx
+++ b/src/components/ProgramCard.tsx
@@ -1,11 +1,23 @@
 import { Link } from 'react-router-dom';
 import type { Program } from '../data/programs';
 
-const APPLICATION_URL =
-  import.meta.env.VITE_APPLICATION_FORM_URL ||
-  'https://www.indianacareerconnect.com';
+const GOOGLE_FORM_URL = import.meta.env.VITE_APPLICATION_FORM_URL || '/apply';
+const INDIANA_CAREER_CONNECT_URL = 'https://www.indianacareerconnect.com';
+
+// State/federal funded programs require Indiana Career Connect first
+const STATE_FUNDED_PROGRAMS = ['WIOA', 'WRG', 'WEX', 'OJT', 'Apprenticeship'];
+
+function getApplicationUrl(program: Program): string {
+  // Check if program has state/federal funding
+  const hasStateFunding = program.funding.some((f) =>
+    STATE_FUNDED_PROGRAMS.includes(f)
+  );
+  
+  return hasStateFunding ? INDIANA_CAREER_CONNECT_URL : GOOGLE_FORM_URL;
+}
 
 export default function ProgramCard({ p }: { p: Program }) {
+  const applicationUrl = getApplicationUrl(p);
   return (
     <article className="group rounded-2xl bg-white p-5 ring-1 ring-slate-200 hover:shadow-md transition">
       <div className="aspect-[16/9] w-full overflow-hidden rounded-xl">
@@ -50,7 +62,7 @@ export default function ProgramCard({ p }: { p: Program }) {
             Program Details
           </Link>
           <a
-            href={APPLICATION_URL}
+            href={applicationUrl}
             target="_blank"
             rel="noopener noreferrer"
             className="rounded-lg border border-brand-border-dark px-4 py-2 font-semibold hover:border-slate-400"

--- a/src/layouts/SiteLayout.tsx
+++ b/src/layouts/SiteLayout.tsx
@@ -2,9 +2,8 @@ import { PropsWithChildren } from 'react';
 import { Link, NavLink } from 'react-router-dom';
 import ChatAssistant from '../components/ChatAssistant';
 
-const APPLICATION_URL =
-  import.meta.env.VITE_APPLICATION_FORM_URL ||
-  'https://www.indianacareerconnect.com';
+// Default to Google Form for general applications
+const APPLICATION_URL = import.meta.env.VITE_APPLICATION_FORM_URL || '/apply';
 
 export default function SiteLayout({ children }: PropsWithChildren) {
   return (

--- a/src/pages/EFHLanding.tsx
+++ b/src/pages/EFHLanding.tsx
@@ -1,9 +1,8 @@
 import ProgramCard from '../components/ProgramCard';
 import { programs } from '../data/programs';
 
-const APPLICATION_URL =
-  import.meta.env.VITE_APPLICATION_FORM_URL ||
-  'https://www.indianacareerconnect.com';
+// Default to Google Form for general applications
+const APPLICATION_URL = import.meta.env.VITE_APPLICATION_FORM_URL || '/apply';
 
 export default function EFHLanding() {
   return (

--- a/src/pages/ProgramPage.tsx
+++ b/src/pages/ProgramPage.tsx
@@ -3,15 +3,15 @@ import { useParams, Link } from 'react-router-dom';
 import { getProgramBySlug, type Program } from '../services/programs';
 import { listCoursesByProgram, type Course } from '../services/courses';
 
-const APPLICATION_URL =
-  import.meta.env.VITE_APPLICATION_FORM_URL ||
-  'https://www.indianacareerconnect.com';
+const GOOGLE_FORM_URL = import.meta.env.VITE_APPLICATION_FORM_URL || '/apply';
+const INDIANA_CAREER_CONNECT_URL = 'https://www.indianacareerconnect.com';
 
 export default function ProgramPage() {
   const { slug } = useParams();
   const [program, setProgram] = useState<Program | null>(null);
   const [courses, setCourses] = useState<Course[]>([]);
   const [error, setError] = useState<string | null>(null);
+  const [applicationUrl, setApplicationUrl] = useState<string>(GOOGLE_FORM_URL);
 
   useEffect(() => {
     if (!slug) return;
@@ -21,6 +21,11 @@ export default function ProgramPage() {
         setProgram(p);
         const cs = await listCoursesByProgram(p.id);
         setCourses(cs);
+        
+        // Check if program requires Indiana Career Connect (state/federal funding)
+        // For now, use Google Form for all programs since we don't have funding data in Supabase
+        // TODO: Add funding column to programs table in Supabase
+        setApplicationUrl(GOOGLE_FORM_URL);
       } catch (e: any) {
         setError(e.message);
       }
@@ -80,7 +85,7 @@ export default function ProgramPage() {
             )}
             <div className="mt-5 flex flex-wrap gap-3">
               <a
-                href={APPLICATION_URL}
+                href={applicationUrl}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="btn text-lg px-6 py-3"


### PR DESCRIPTION
- Programs with state/federal funding (WIOA, WRG, WEX, OJT, Apprenticeship) → Indiana Career Connect
- Other programs (Self-Pay, Employer Sponsored) → Google Form (VITE_APPLICATION_FORM_URL)
- Updated ProgramCard, ProgramPage, SiteLayout, EFHLanding
- Indiana Career Connect only required for government-funded programs
- Google Form is default for general applications