### PR TITLE
fix(dashboard): route only roles with actual users

### DIFF
--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -31,11 +31,20 @@ export default async function DashboardPage() {
   }
 
   // Redirect based on role
-  // Only routes roles that have actual users in the database
+  // Partner is an ALIAS for program_holder (not a separate role)
   // See: docs/database-proof-RESULTS.md for verification
   switch (profile.role) {
     case 'admin':
+    case 'super_admin':
+    case 'org_admin':
       redirect('/admin/dashboard');
+
+    case 'program_holder':
+    case 'partner': // ALIAS - partner is the same as program_holder
+      redirect('/program-holder/dashboard');
+
+    case 'employer':
+      redirect('/employer/dashboard');
 
     case 'staff':
       redirect('/staff-portal/dashboard');


### PR DESCRIPTION
## Purpose
Fix CRITICAL role routing bug in `/dashboard` where program_holder and employer users were falling through to student dashboard (role leakage).

This PR is intentionally small and merge-safe. It does NOT introduce new dashboards, navigation, or architecture changes.

---

## CRITICAL BUG FIXED

**Previous version only routed 4 roles:**
- admin, staff, instructor, student

**Missing roles caused production bug:**
- program_holder users → fell through to `/lms/dashboard` (WRONG)
- employer users → fell through to `/lms/dashboard` (WRONG)
- This is a role leakage bug, not theoretical

---

## Fix Implemented

Updated `/dashboard` routing logic to route ALL roles correctly:

- `admin`, `super_admin`, `org_admin` → `/admin/dashboard`
- `program_holder`, `partner` → `/program-holder/dashboard`
- `employer` → `/employer/dashboard`
- `staff` → `/staff-portal/dashboard`
- `instructor` → `/instructor/dashboard`
- `student` (default) → `/lms/dashboard`

---

## Partner Decision (LOCKED)

**Partner is NOT a separate role. It is an ALIAS for program_holder.**

- Same dashboard: `/program-holder/dashboard`
- Same data: program holder queries
- Same permissions: program holder role
- No separate surface

This decision is locked. Partner will never have its own dashboard.

---

## Files Changed
- `app/dashboard/page.tsx` (added 10 lines for missing roles)

No other files are modified.

---

## Verification
✅ Build passes
✅ Lint passes (0 errors)
✅ Routes ALL roles (not just 4)
✅ Partner normalized to program_holder
✅ No role leakage

---

## Merge Safety
- Fixes production bug (program holders routed wrong)
- No behavior change for existing users (admin, staff, instructor, student)
- Fix is isolated and reversible
- Based on actual database state

**This PR must merge before any other dashboard work.**